### PR TITLE
ci: seperate workflow for format check

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -126,9 +126,4 @@ jobs:
       
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2
-      
-      
-    - name: Formatting check
-      working-directory: meshFields
-      shell: bash
-      run: clang-format --dry-run -Werror src/* test/*
+

--- a/.github/workflows/formatCheck.yml
+++ b/.github/workflows/formatCheck.yml
@@ -1,0 +1,23 @@
+name: Format check
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '23 14 * * 3'
+
+jobs:
+  formatCheck:
+    runs-on: ubuntu-latest
+    steps:
+    - name: MeshFields Checkout repo
+      uses: actions/checkout@v2
+      with:
+        repository: SCOREC/meshFields
+        path: meshFields
+        
+    - name: Format check
+      working-directory: meshFields
+      shell: bash
+      run: clang-format --dry-run -Werror src/* test/*

--- a/src/SliceWrapper.hpp
+++ b/src/SliceWrapper.hpp
@@ -24,7 +24,8 @@ template <class SliceType, class T> struct SliceWrapper {
   */
 
   KOKKOS_INLINE_FUNCTION
-  T &access(int s, int a) const { return slice.access(s, a); }
+  T &access(int s, int a) const 
+  { return slice.access(s, a); }
 
   KOKKOS_INLINE_FUNCTION
   auto &access(int s, int a, int i) const { return slice.access(s, a, i); }

--- a/src/SliceWrapper.hpp
+++ b/src/SliceWrapper.hpp
@@ -24,8 +24,7 @@ template <class SliceType, class T> struct SliceWrapper {
   */
 
   KOKKOS_INLINE_FUNCTION
-  T &access(int s, int a) const 
-  { return slice.access(s, a); }
+  T &access(int s, int a) const { return slice.access(s, a); }
 
   KOKKOS_INLINE_FUNCTION
   auto &access(int s, int a, int i) const { return slice.access(s, a, i); }


### PR DESCRIPTION
The build-test workflow is not a dependency of the format check and the two can run in parallel.