### PR TITLE
Convert usage of DeviceTypes to MemorySpaces

### DIFF
--- a/src/CabanaController.hpp
+++ b/src/CabanaController.hpp
@@ -86,7 +86,7 @@ public:
   typedef ExecutionSpace exe;
   static const int MAX_RANK = 4; // Including num_tuples -> so 3 additional extents
   static constexpr int vecLen =
-      Cabana::AoSoA<DataTypes, DeviceType>::vector_length;
+      Cabana::AoSoA<DataTypes, MemorySpace>::vector_length;
 
 private:
   // all the type defenitions that are needed us to get the type of the slice
@@ -103,7 +103,7 @@ private:
 
   template <class T, int stride>
   using member_slice_t =
-      Cabana::Slice<T, DeviceType, Cabana::DefaultAccessMemory, vecLen, stride>;
+      Cabana::Slice<T, MemorySpace, Cabana::DefaultAccessMemory, vecLen, stride>;
 
   template <class T, int stride>
   using wrapper_slice_t = CabanaSliceWrapper<member_slice_t<T, stride>, T>;
@@ -138,7 +138,7 @@ private:
 
   
   // member vaiables
-  Cabana::AoSoA<DataTypes, DeviceType, vecLen> aosoa;
+  Cabana::AoSoA<DataTypes, MemorySpace, vecLen> aosoa;
   const int num_tuples;
   unsigned short theta = 0;
   int extent_sizes[sizeof...(Ts)][MAX_RANK];


### PR DESCRIPTION
Update Meshfields to properly use Cabana's updated interface(https://github.com/ECP-copa/Cabana/commit/5e429e03d9fafdc8388d29ecfa978a82b7c4b575), which uses MemorySpaces in place of DeviceTypes.