### PR TITLE
Host the doxygen documentation through GitHub Pages

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -135,9 +135,13 @@ jobs:
       if: matrix.compiler == 'g++' && matrix.build_type == 'Release'
       run: doxygen ${{github.workspace}}/build-meshFields/Doxyfile
     
+    - name: Upload artifact
+      if: matrix.compiler == 'g++' && matrix.build_type == 'Release'
+      uses: actions/upload-pages-artifact@v3
+      with:
+        path: ./docs/html
+
     - name: Deploy to GitHub Pages
       if: matrix.compiler == 'g++' && matrix.build_type == 'Release'
-      uses: peaceiris/actions-gh-pages@v4
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/html
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
Add a step to host the artifact on GitHub Pages at the end of the CI tests.