### PR TITLE
Fix missing return statement warnings

### DIFF
--- a/src/MeshField_ShapeField.hpp
+++ b/src/MeshField_ShapeField.hpp
@@ -96,12 +96,12 @@ struct QuadraticAccessor {
 
   KOKKOS_FUNCTION
   auto &operator()(int node, int component, int entity, Mesh_Topology t) const {
-    if (t!= Vertex && t != Edge) {
+    if (t != Vertex && t != Edge) {
       Kokkos::printf("%d is not a support topology\n", t);
       assert(false);
     }
     return (t == Vertex) ? vtxField(node, component, entity)
-                        : edgeField(node, component, entity);
+                         : edgeField(node, component, entity);
   }
 };
 


### PR DESCRIPTION
Resolved the `missing return statement at end of non-void function` warnings reported in CDash builds using GCC 13.2.0.