### PR TITLE
Update workflows to use `SCOREC/omega_h`

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -51,7 +51,7 @@ jobs:
     - name: Omega_h Checkout repo
       uses: actions/checkout@v4
       with:
-        repository: sandialabs/omega_h
+        repository: SCOREC/omega_h
         path: omegah
 
     - name: Omega_h Configure CMake

--- a/.github/workflows/doxygen-gh-pages.yml
+++ b/.github/workflows/doxygen-gh-pages.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Omega_h Checkout repo
         uses: actions/checkout@v4
         with:
-            repository: sandialabs/omega_h
+            repository: SCOREC/omega_h
             path: omegah
 
       - name: Omega_h Configure CMake


### PR DESCRIPTION
Use `SCOREC/omega_h` instead of `sandialabs/omega_h` in workflows