### PR TITLE
Add omega_h location in find_dependency

### DIFF
--- a/config.cmake.in
+++ b/config.cmake.in
@@ -8,6 +8,6 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Omega_h CONFIG HINTS @Omega_h_DIR@)
 if (MeshFields_USE_Cabana)
-  find_dependency(Cabana)
+  find_dependency(Cabana CONFIG HINTS @Cabana_DIR@)
 endif()
 

--- a/config.cmake.in
+++ b/config.cmake.in
@@ -6,7 +6,7 @@ check_required_components(meshfields)
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(Omega_h)
+find_dependency(Omega_h CONFIG HINTS @Omega_h_DIR@)
 if (MeshFields_USE_Cabana)
   find_dependency(Cabana)
 endif()


### PR DESCRIPTION
I do not know if there was any specific reason to not provide `Omega_h`'s location. It should help by not asking Omega_h's location to the downstream users. 