### PR TITLE
Adding parametric coordinates to MeshField Shapes

### DIFF
--- a/src/MeshField_Shape.hpp
+++ b/src/MeshField_Shape.hpp
@@ -97,6 +97,16 @@ struct LinearTriangleCoordinateShape {
   constexpr static Mesh_Topology DofHolders[1] = {Vertex};
   constexpr static size_t Order = 1;
 
+  // Get Parametric Coordinates
+  KOKKOS_INLINE_FUNCTION
+  Kokkos::Array<Real, meshEntDim * numNodes> getParamCoords() const {
+    // clang-format off
+    return { 0,0,  //first vector
+              1, 0,
+              0, 1};
+    // clang-format on
+  }
+
   KOKKOS_INLINE_FUNCTION
   Kokkos::Array<Real, numNodes> getValues(Vector3 const &xi) const {
     assert(greaterThanOrEqualZero(xi));


### PR DESCRIPTION
This PR proposes a way to embed parametric coordinates directly in `MeshField` shape structs. This will:
- allow `Omega_h_layout` to compute DOF coordinates for higher order shape functions.
- extend `Omega_h_layout` implementation to 3D use cases. See [`Omega_h_layout.cpp`](https://github.com/SCOREC/pcms/blob/f87d4aa7898234ec17b9b18cb76913c54d3fac06/src/pcms/adapter/omega_h/omega_h_field_layout.cpp#L81-L92).
